### PR TITLE
Update members.csv: add REStud policy URL, fix trailing newline

### DIFF
--- a/_data/members.csv
+++ b/_data/members.csv
@@ -1,5 +1,5 @@
 name,affiliation,journals,journal_url,guidance,policy,archive
 Lars Vilhuber,Cornell University,AEA Journals,https://www.aeaweb.org/journals/,https://aeadataeditor.github.io/aea-de-guidance/,https://www.aeaweb.org/journals/data/data-code-policy,https://www.openicpsr.org/openicpsr/search/aea/studies
-Andrea Moro,Vanderbilt University,Review of Economic Studies,https://academic.oup.com/restud,https://restud.dataeditor.group/,,https://zenodo.org/communities/restud-replication/
+Andrea Moro,Vanderbilt University,Review of Economic Studies,https://academic.oup.com/restud,https://restud.dataeditor.group/,https://restud.dataeditor.group/after/,https://zenodo.org/communities/restud-replication/
 Christoph Scheuch,Humboldt University of Berlin,Review of Financial Studies,https://academic.oup.com/rfs,https://review-of-financial-studies.github.io/,https://sfs.org/review-of-financial-studies/code-sharing-policy/,https://dataverse.harvard.edu/dataverse/rfs
 Florian Oswald,University of Turin,Journal of Political Economy,https://www.journals.uchicago.edu/toc/jpe/current,https://jpedataeditor.github.io/,https://www.journals.uchicago.edu/journals/jpe/datapolicy,https://dataverse.harvard.edu/dataverse/JPE


### PR DESCRIPTION
- Added missing policy URL for Andrea Moro (REStud): https://restud.dataeditor.group/after/
- Fixed missing trailing newline at end of file